### PR TITLE
新改訳聖書第3版を引用していることを表示する

### DIFF
--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -19,6 +19,7 @@
 
   <%- if @books.present? -%>
   <div id="book-name">
+    新改訳聖書第3版
     <%= @books.first.book_name.japanese %> / <%= @books.first.book_name.english %>
     : <%= @books.first.chapter %>
   </div>


### PR DESCRIPTION
## 概要

2024年3月26日から以下が適用されます。
https://www.seisho.or.jp/s2017/quotation-policy/?fbclid=IwAR1aC58UR4vIiaeBjd63jR3d2DB4XfJpgIKYHwJSTjdqfhwMIz_C6cP1CWo_aem_AWpS5Z8IfZh9Wh4EVgpbBC-SqNaezW9dQJfB_S9Quxsw8WHDzh2pbWgEbkRrHrFrBxA#i-6

> 出所を明示する（新改訳聖書を利用していることが動画内で分かるようにし、概要欄などにも出所を明示する）

こちらを対応する必要があるため、表示します。